### PR TITLE
Fix land scout builder to use swarm version, fix BuildScoutLocationsS…

### DIFF
--- a/AI-Swarm/hook/lua/platoon.lua
+++ b/AI-Swarm/hook/lua/platoon.lua
@@ -68,7 +68,7 @@ Platoon = Class(SwarmPlatoonClass) {
                 eng.NotBuildingThread = eng:ForkThread(eng.PlatoonHandle.WatchForNotBuilding)
             end
             -- see if we can move there first
-            if AIUtils.EngineerMoveWithSafePath(aiBrain, eng, buildLocation) then
+            if AIUtils.EngineerMoveWithSafePathSwarm(aiBrain, eng, buildLocation) then
                 if not eng or eng.Dead or not eng.PlatoonHandle or not aiBrain:PlatoonExists(eng.PlatoonHandle) then
                     if eng then eng.ProcessBuild = nil end
                     return

--- a/AI-Swarm/lua/AI/AIBuilders/Expansion.lua
+++ b/AI-Swarm/lua/AI/AIBuilders/Expansion.lua
@@ -54,7 +54,7 @@ BuilderGroup {
     
     Builder {
         BuilderName = 'S1 Vacant Start Location',                               -- Random Builder Name.
-        PlatoonTemplate = 'EngineerBuilder',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
+        PlatoonTemplate = 'T1EngineerBuilderSwarm',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
         Priority = 500,                                                        -- Priority. Higher priotity will be build more often then lower priotity.
         InstanceCount = 4,                                                      -- Number of plattons that will be formed with this template.
         BuilderConditions = {
@@ -92,7 +92,7 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'S1 Vacant Start Location trans',                               -- Random Builder Name.
-        PlatoonTemplate = 'EngineerBuilder',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
+        PlatoonTemplate = 'T1EngineerBuilderSwarm',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
         Priority = 500,                                                        -- Priority. Higher priotity will be build more often then lower priotity.
         InstanceCount = 1,                                                      -- Number of plattons that will be formed with this template.
         BuilderConditions = {
@@ -130,7 +130,7 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'S1 Vacant Expansion Area',                               -- Random Builder Name.
-        PlatoonTemplate = 'EngineerBuilder',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
+        PlatoonTemplate = 'T1EngineerBuilderSwarm',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
         Priority = 500,                                                        -- Priority. Higher priotity will be build more often then lower priotity.
         InstanceCount = 4,                                                      -- Number of plattons that will be formed with this template.
         BuilderConditions = {
@@ -168,7 +168,7 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'S1 Vacant Expansion Area trans',                               -- Random Builder Name.
-        PlatoonTemplate = 'EngineerBuilder',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
+        PlatoonTemplate = 'T1EngineerBuilderSwarm',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
         Priority = 500,                                                        -- Priority. Higher priotity will be build more often then lower priotity.
         InstanceCount = 2,                                                      -- Number of plattons that will be formed with this template.
         BuilderConditions = {
@@ -206,7 +206,7 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'S1 Naval Builder',                                       -- Random Builder Name.
-        PlatoonTemplate = 'EngineerBuilder',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
+        PlatoonTemplate = 'T1EngineerBuilderSwarm',                                    -- Template Name. These units will be formed. See: "\lua\AI\PlatoonTemplates\"
         Priority = 500,                                                        -- Priority. Higher priotity will be build more often then lower priotity.
         InstanceCount = 2,                                                      -- Number of plattons that will be formed with this template.
         BuilderConditions = {

--- a/hook/lua/AI/aibehaviors.lua
+++ b/hook/lua/AI/aibehaviors.lua
@@ -88,6 +88,9 @@ function StructureUpgradeThreadSwarm(unit, aiBrain, upgradeSpec, bypasseco)
         bypasseco = false
     end
     local upgradebp = aiBrain:GetUnitBlueprint(upgradeID)
+    if not upgradebp then
+        return
+    end
     local alternativebp = false
     local factionCategory = false
     --LOG("What is upgradeID at the Start " ..repr(upgradeID).. " and unit was " ..repr(unit:GetBlueprint().Description))
@@ -113,26 +116,23 @@ function StructureUpgradeThreadSwarm(unit, aiBrain, upgradeSpec, bypasseco)
         if upgradeID then
             -- This is the support factory compatibility code
             if EntityCategoryContains( FACTORYLAND, unit) then -- 1: UEF, 2: Aeon, 3: Cybran, 4: Seraphim, 5: Nomads
-                if EntityCategoryContains( FLSF1, unit) then
+                if EntityCategoryContains( FLSF1, unit) and (aiBrain.HQs[factionCategory]['LAND']['TECH2'] > 0 or aiBrain.HQs[factionCategory]['LAND']['TECH3'] > 0) then
                     --LOG(aiBrain.Nickname.. " I am a T1 Land Factory")
-                    if aiBrain.HQs[factionCategory]['LAND']['TECH2'] > 0 or aiBrain.HQs[factionCategory]['LAND']['TECH3'] > 0 then
-                        if unitFactionIndex == 1 then
-                            alternativebp = 'zeb9501'
-                        elseif unitFactionIndex == 2 then
-                            alternativebp = 'zab9501'
-                        elseif unitFactionIndex == 3 then
-                            alternativebp = 'zrb9501'
-                        elseif unitFactionIndex == 4 then
-                            alternativebp = 'zsb9501'
-                        end
-                        --LOG(aiBrain.Nickname.. " I am upgrading to a T2 Support Factory")
-                        upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
-                        upgradeID = alternativebp
+                    if unitFactionIndex == 1 then
+                        alternativebp = 'zeb9501'
+                    elseif unitFactionIndex == 2 then
+                        alternativebp = 'zab9501'
+                    elseif unitFactionIndex == 3 then
+                        alternativebp = 'zrb9501'
+                    elseif unitFactionIndex == 4 then
+                        alternativebp = 'zsb9501'
                     end
+                    --LOG(aiBrain.Nickname.. " I am upgrading to a T2 Support Factory")
+                    upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
+                    upgradeID = alternativebp
                     --LOG("What is unitFactionIndex " ..repr(unitFactionIndex))
                     --LOG("What is alternativebp " ..repr(alternativebp))
                 end
-
                 if EntityCategoryContains( FLSF2, unit) and aiBrain.HQs[factionCategory]['LAND']['TECH3'] > 0 then
                     --LOG(aiBrain.Nickname.. " I am a T2 Land Factory")
                     if unitFactionIndex == 1 then
@@ -148,26 +148,22 @@ function StructureUpgradeThreadSwarm(unit, aiBrain, upgradeSpec, bypasseco)
                     upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
                     upgradeID = alternativebp
                 end
-
                 if EntityCategoryContains( FLHQ2, unit) then
                     LOG(aiBrain.Nickname.. " I am a T2 Land HQ and can only upgrade to a T3 HQ")
                 end
-
             elseif EntityCategoryContains( FACTORYAIR, unit) then -- 1: UEF, 2: Aeon, 3: Cybran, 4: Seraphim, 5: Nomads
-                if EntityCategoryContains( FASF1, unit) then
-                    if aiBrain.HQs[factionCategory]['AIR']['TECH2'] > 0 or aiBrain.HQs[factionCategory]['AIR']['TECH3'] > 0 then
-                        if unitFactionIndex == 1 then
-                           alternativebp = 'zeb9502'
-                        elseif unitFactionIndex == 2 then
-                            alternativebp = 'zab9502'
-                        elseif unitFactionIndex == 3 then
-                            alternativebp = 'zrb9502'
-                        elseif unitFactionIndex == 4 then
-                            alternativebp = 'zsb9502'
-                        end
-                        upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
-                        upgradeID = alternativebp
+                if EntityCategoryContains( FASF1, unit) and (aiBrain.HQs[factionCategory]['AIR']['TECH2'] > 0 or aiBrain.HQs[factionCategory]['AIR']['TECH3'] > 0) then
+                    if unitFactionIndex == 1 then
+                        alternativebp = 'zeb9502'
+                    elseif unitFactionIndex == 2 then
+                        alternativebp = 'zab9502'
+                    elseif unitFactionIndex == 3 then
+                        alternativebp = 'zrb9502'
+                    elseif unitFactionIndex == 4 then
+                        alternativebp = 'zsb9502'
                     end
+                    upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
+                    upgradeID = alternativebp
                 end
 
                 if EntityCategoryContains( FASF2, unit) and aiBrain.HQs[factionCategory]['AIR']['TECH3'] > 0 then
@@ -183,24 +179,20 @@ function StructureUpgradeThreadSwarm(unit, aiBrain, upgradeSpec, bypasseco)
                     upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
                     upgradeID = alternativebp
                 end
-
             elseif EntityCategoryContains( FACTORYNAVAL, unit) then -- 1: UEF, 2: Aeon, 3: Cybran, 4: Seraphim, 5: Nomads
-                if EntityCategoryContains( FNSF1, unit) then
-                    if aiBrain.HQs[factionCategory]['NAVAL']['TECH2'] > 0 or aiBrain.HQs[factionCategory]['NAVAL']['TECH3'] > 0 then
-                        if unitFactionIndex == 1 then
-                            alternativebp = 'zeb9503'
-                        elseif unitFactionIndex == 2 then
-                            alternativebp = 'zab9503'
-                        elseif unitFactionIndex == 3 then
-                            alternativebp = 'zrb9503'
-                        elseif unitFactionIndex == 4 then
-                            alternativebp = 'zsb9503'
-                        end
-                        upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
-                        upgradeID = alternativebp
+                if EntityCategoryContains( FNSF1, unit) and (aiBrain.HQs[factionCategory]['NAVAL']['TECH2'] > 0 or aiBrain.HQs[factionCategory]['NAVAL']['TECH3'] > 0) then
+                    if unitFactionIndex == 1 then
+                        alternativebp = 'zeb9503'
+                    elseif unitFactionIndex == 2 then
+                        alternativebp = 'zab9503'
+                    elseif unitFactionIndex == 3 then
+                        alternativebp = 'zrb9503'
+                    elseif unitFactionIndex == 4 then
+                        alternativebp = 'zsb9503'
                     end
+                    upgradebp = aiBrain:GetUnitBlueprint(alternativebp)
+                    upgradeID = alternativebp
                 end
-
                 if EntityCategoryContains( FNSF2, unit) and aiBrain.HQs[factionCategory]['NAVAL']['TECH3'] > 0 then
                     if unitFactionIndex == 1 then
                         alternativebp = 'zeb9603'
@@ -216,6 +208,7 @@ function StructureUpgradeThreadSwarm(unit, aiBrain, upgradeSpec, bypasseco)
                 end
             --LOG("What is upgradeID " ..repr(upgradebp))
             end
+            return upgradebp
         end
     end
 
@@ -303,137 +296,155 @@ function StructureUpgradeThreadSwarm(unit, aiBrain, upgradeSpec, bypasseco)
         --LOG('* AI-Swarm: Upgrade main loop starting for'..aiBrain.Nickname)
         SWARMWAIT(upgradeSpec.UpgradeCheckWait * 10)
 
-        DecideUpgradeBP()
-        GetUpgradeEconomy()
-        --LOG("What is Upgrade BP " ..repr(upgradebp))
-        upgradeSpec = aiBrain:GetUpgradeSpecSwarm(unit)
-        --LOG('Upgrade Spec '..repr(upgradeSpec))
-        --LOG('Current low mass trigger '..upgradeSpec.MassLowTrigger)
-
-        if EntityCategoryContains( EXTRACTORALL, unit) and not ExtractorClosestSwarm(aiBrain, unit, unitBp) then
-            --LOG('This is not the Closest Extractor ' .. ' ' ..repr(unit:GetBlueprint().Description))
-            SWARMWAIT(10)
-            continue
-        end
-
-        if EntityCategoryContains( EXTRACTORALL, unit) then
-            
-            if (not unit.MAINBASE) or (unit.MAINBASE and not bypasseco and GetEconomyStored( aiBrain, 'MASS') < (massNeeded * 0.5)) then
-               --LOG('Mainbase Unit is ' .. ' ' ..repr(unit:GetBlueprint().Description))
-                if HaveUnitRatio( aiBrain, 1.6, categories.MASSEXTRACTION * categories.TECH1, '>=', categories.MASSEXTRACTION * categories.TECH2 ) and unitTech == 'TECH2' and unitType == 'MASSEXTRACTION' then
-                    --LOG('Too few tech2 extractors to go tech3')
-                    ecoStartTime = ecoStartTime + upgradeSpec.UpgradeCheckWait
-                    SWARMWAIT(10)
-                    continue
-                end
+        local upgradeBP = DecideUpgradeBP()
+        local waitHQLoop = false
+        if upgradeBP and upgradeBP.CategoriesHash.SUPPORTFACTORY then
+            if upgradeBP.CategoriesHash.LAND and upgradeBP.CategoriesHash.TECH2 and (aiBrain.HQs[factionCategory]['LAND']['TECH2'] < 1 and aiBrain.HQs[factionCategory]['LAND']['TECH3'] < 1) then
+                waitHQLoop = true
+            elseif upgradeBP.CategoriesHash.LAND and upgradeBP.CategoriesHash.TECH3 and aiBrain.HQs[factionCategory]['LAND']['TECH3'] < 1 then
+                waitHQLoop = true
+            elseif upgradeBP.CategoriesHash.AIR and upgradeBP.CategoriesHash.TECH2 and (aiBrain.HQs[factionCategory]['AIR']['TECH2'] < 1 and aiBrain.HQs[factionCategory]['AIR']['TECH3'] < 1) then
+                waitHQLoop = true
+            elseif upgradeBP.CategoriesHash.AIR and upgradeBP.CategoriesHash.TECH3 and aiBrain.HQs[factionCategory]['AIR']['TECH3'] < 1 then
+                waitHQLoop = true
+            elseif upgradeBP.CategoriesHash.NAVAL and upgradeBP.CategoriesHash.TECH2 and (aiBrain.HQs[factionCategory]['NAVAL']['TECH2'] < 1 and aiBrain.HQs[factionCategory]['NAVAL']['TECH3'] < 1) then
+                waitHQLoop = true
+            elseif upgradeBP.CategoriesHash.NAVAL and upgradeBP.CategoriesHash.TECH3 and aiBrain.HQs[factionCategory]['NAVAL']['TECH3'] < 1 then
+                waitHQLoop = true
             end
         end
+        if not waitHQLoop then
+            GetUpgradeEconomy()
+            --LOG("What is Upgrade BP " ..repr(upgradebp))
+            upgradeSpec = aiBrain:GetUpgradeSpecSwarm(unit)
+            --LOG('Upgrade Spec '..repr(upgradeSpec))
+            --LOG('Current low mass trigger '..upgradeSpec.MassLowTrigger)
 
-        --LOG('Current Upgrade Limit is :'..upgradeNumLimit)
-        --LOG('Upgrade Issued '..aiBrain.UpgradeIssued..' Upgrade Issued Limit '..aiBrain.UpgradeIssuedLimit)
-        if aiBrain.UpgradeIssued < aiBrain.UpgradeIssuedLimit then
-            --LOG('* AI-Swarm:'..aiBrain.Nickname)
-            --LOG('* AI-Swarm: UpgradeIssues and UpgradeIssuedLimit are set')
-            massStorage = GetEconomyStored( aiBrain, 'MASS')
-            --LOG('* AI-Swarm: massStorage'..massStorage)
-            energyStorage = GetEconomyStored( aiBrain, 'ENERGY')
-            --LOG('* AI-Swarm: energyStorage'..energyStorage)
-            massStorageRatio = GetEconomyStoredRatio(aiBrain, 'MASS')
-            --LOG('* AI-Swarm: massStorageRatio'..massStorageRatio)
-            energyStorageRatio = GetEconomyStoredRatio(aiBrain, 'ENERGY')
-            --LOG('* AI-Swarm: energyStorageRatio'..energyStorageRatio)
-            massIncome = GetEconomyIncome(aiBrain, 'MASS')
-            --LOG('* AI-Swarm: massIncome'..massIncome)
-            massRequested = GetEconomyRequested(aiBrain, 'MASS')
-            --LOG('* AI-Swarm: massRequested'..massRequested)
-            energyIncome = GetEconomyIncome(aiBrain, 'ENERGY')
-            --LOG('* AI-Swarm: energyIncome'..energyIncome)
-            energyRequested = GetEconomyRequested(aiBrain, 'ENERGY')
-            --LOG('* AI-Swarm: energyRequested'..energyRequested)
-            massTrend = aiBrain.EconomyOverTimeCurrent.MassTrendOverTime
-            --LOG('* AI-Swarm: massTrend'..massTrend)
-            energyTrend = aiBrain.EconomyOverTimeCurrent.EnergyTrendOverTime
-            --LOG('* AI-Swarm: energyTrend'..energyTrend)
-            --massEfficiency = math.min(massIncome / massRequested, 2)
-            --LOG('* AI-Swarm: massEfficiency'..massEfficiency)
-            --energyEfficiency = math.min(energyIncome / energyRequested, 2)
-            --LOG('* AI-Swarm: energyEfficiency'..energyEfficiency)
-
-            if (aiBrain.EconomyOverTimeCurrent.MassEfficiencyOverTime >= upgradeSpec.MassLowTrigger and aiBrain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= upgradeSpec.EnergyLowTrigger)
-                or ((massStorageRatio > .60 and energyStorageRatio > .40))
-                or (massStorage > (massNeeded * .7) and energyStorage > (energyNeeded * .7 ) ) or bypasseco then
-                    if bypasseco then
-                        --LOG('Low Triggered bypasseco')
-                    else
-                        --LOG('* AI-Swarm: low_trigger_good = true')
-                    end
-                --LOG('* AI-Swarm: low_trigger_good = true')
-            else
-                --LOG(aiBrain.Nickname.. " " ..repr(unit:GetBlueprint().Description.. " " ..unit.Sync.id.. " Efficiency FAILS and unit was " ..repr(unit:GetBlueprint().Description)))
+            if EntityCategoryContains( EXTRACTORALL, unit) and not ExtractorClosestSwarm(aiBrain, unit, unitBp) then
+                --LOG('This is not the Closest Extractor ' .. ' ' ..repr(unit:GetBlueprint().Description))
                 SWARMWAIT(10)
                 continue
             end
 
-            if (massEfficiency <= upgradeSpec.MassHighTrigger and energyEfficiency <= upgradeSpec.EnergyHighTrigger) then
-                --LOG('* AI-Swarm: hi_trigger_good = true')
-            else
-                --LOG(aiBrain.Nickname.. " " ..repr(unit:GetBlueprint().Description.. " " ..unit.Sync.id.. " High Trigger FAILS "))
-                continue
-            end
-
-            if ( massTrend >= massTrendNeeded and energyTrend >= energyTrendNeeded and energyTrend >= energyMaintenance )
-				or ( massStorage >= (massNeeded * .7) and energyStorage > (energyNeeded * .7) ) or bypasseco then
-				-- we need to have 15% of the resources stored -- some things like MEX can bypass this last check
-				if (massStorage > ( massNeeded * .15 * upgradeSpec.MassLowTrigger) and energyStorage > ( energyNeeded * .15 * upgradeSpec.EnergyLowTrigger)) or bypasseco then
-
-                    if aiBrain.UpgradeIssued < aiBrain.UpgradeIssuedLimit then
-
-						if not unit.Dead then
-
-                            upgradeIssued = true
-                            --LOG(aiBrain.Nickname.. " " ..repr(unit:GetBlueprint().Description.. " " ..unit.Sync.id.. " Upgrading to " ..repr(upgradebp.Description)))
-                            IssueUpgrade({unit}, upgradeID)
-
-                            -- if upgrade issued and not completely full --
-                            if massStorageRatio < 1 or energyStorageRatio < 1 then
-                                ForkThread(StructureUpgradeDelaySwarm, aiBrain, aiBrain.UpgradeIssuedPeriod)  -- delay the next upgrade by the full amount
-                            else
-                                ForkThread(StructureUpgradeDelaySwarm, aiBrain, aiBrain.UpgradeIssuedPeriod * .5)     -- otherwise halve the delay period
-                            end
-
-                            while (not unit.Dead) and (not unit.UnitBeingBuilt.Blueprint.BlueprintId == upgradeID) do
-                                SWARMWAIT(50)
-                            end
-                        end
-
-                        if unit.Dead then
-                            --LOG("*AI DEBUG "..aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." to "..upgradeID.." failed.  Dead is "..repr(unit.Dead))
-                            upgradeIssued = false
-                        end
-
-                        if upgradeIssued then
-                            SWARMWAIT(10)
-                            continue
-                        end
-                    else
-                        LOG(aiBrain.Nickname.. " Could not do an upgrade because the UpgradeIssuedLimit was exceeded " .. repr(aiBrain.UpgradeIssued) .. " and UpgradedIsssuedLimit was actually " .. repr(aiBrain.UpgradeIssuedLimit))
+            if EntityCategoryContains( EXTRACTORALL, unit) then
+                
+                if (not unit.MAINBASE) or (unit.MAINBASE and not bypasseco and GetEconomyStored( aiBrain, 'MASS') < (massNeeded * 0.5)) then
+                --LOG('Mainbase Unit is ' .. ' ' ..repr(unit:GetBlueprint().Description))
+                    if HaveUnitRatio( aiBrain, 1.6, categories.MASSEXTRACTION * categories.TECH1, '>=', categories.MASSEXTRACTION * categories.TECH2 ) and unitTech == 'TECH2' and unitType == 'MASSEXTRACTION' then
+                        --LOG('Too few tech2 extractors to go tech3')
+                        ecoStartTime = ecoStartTime + upgradeSpec.UpgradeCheckWait
+                        SWARMWAIT(10)
+                        continue
                     end
                 end
-            else
-                if not ( massTrend >= massTrendNeeded ) then
-                    --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS MASS Trend trigger "..massTrend.." needed "..massTrendNeeded)
+            end
+
+            --LOG('Current Upgrade Limit is :'..upgradeNumLimit)
+            --LOG('Upgrade Issued '..aiBrain.UpgradeIssued..' Upgrade Issued Limit '..aiBrain.UpgradeIssuedLimit)
+            if aiBrain.UpgradeIssued < aiBrain.UpgradeIssuedLimit then
+                --LOG('* AI-Swarm:'..aiBrain.Nickname)
+                --LOG('* AI-Swarm: UpgradeIssues and UpgradeIssuedLimit are set')
+                massStorage = GetEconomyStored( aiBrain, 'MASS')
+                --LOG('* AI-Swarm: massStorage'..massStorage)
+                energyStorage = GetEconomyStored( aiBrain, 'ENERGY')
+                --LOG('* AI-Swarm: energyStorage'..energyStorage)
+                massStorageRatio = GetEconomyStoredRatio(aiBrain, 'MASS')
+                --LOG('* AI-Swarm: massStorageRatio'..massStorageRatio)
+                energyStorageRatio = GetEconomyStoredRatio(aiBrain, 'ENERGY')
+                --LOG('* AI-Swarm: energyStorageRatio'..energyStorageRatio)
+                massIncome = GetEconomyIncome(aiBrain, 'MASS')
+                --LOG('* AI-Swarm: massIncome'..massIncome)
+                massRequested = GetEconomyRequested(aiBrain, 'MASS')
+                --LOG('* AI-Swarm: massRequested'..massRequested)
+                energyIncome = GetEconomyIncome(aiBrain, 'ENERGY')
+                --LOG('* AI-Swarm: energyIncome'..energyIncome)
+                energyRequested = GetEconomyRequested(aiBrain, 'ENERGY')
+                --LOG('* AI-Swarm: energyRequested'..energyRequested)
+                massTrend = aiBrain.EconomyOverTimeCurrent.MassTrendOverTime
+                --LOG('* AI-Swarm: massTrend'..massTrend)
+                energyTrend = aiBrain.EconomyOverTimeCurrent.EnergyTrendOverTime
+                --LOG('* AI-Swarm: energyTrend'..energyTrend)
+                --massEfficiency = math.min(massIncome / massRequested, 2)
+                --LOG('* AI-Swarm: massEfficiency'..massEfficiency)
+                --energyEfficiency = math.min(energyIncome / energyRequested, 2)
+                --LOG('* AI-Swarm: energyEfficiency'..energyEfficiency)
+
+                if (aiBrain.EconomyOverTimeCurrent.MassEfficiencyOverTime >= upgradeSpec.MassLowTrigger and aiBrain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= upgradeSpec.EnergyLowTrigger)
+                    or ((massStorageRatio > .60 and energyStorageRatio > .40))
+                    or (massStorage > (massNeeded * .7) and energyStorage > (energyNeeded * .7 ) ) or bypasseco then
+                        if bypasseco then
+                            --LOG('Low Triggered bypasseco')
+                        else
+                            --LOG('* AI-Swarm: low_trigger_good = true')
+                        end
+                    --LOG('* AI-Swarm: low_trigger_good = true')
+                else
+                    --LOG(aiBrain.Nickname.. " " ..repr(unit:GetBlueprint().Description.. " " ..unit.Sync.id.. " Efficiency FAILS and unit was " ..repr(unit:GetBlueprint().Description)))
+                    SWARMWAIT(10)
+                    continue
                 end
-                if not ( energyTrend >= energyTrendNeeded ) then
-                    --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS ENER Trend trigger "..energyTrend.." needed "..energyTrendNeeded)
+
+                if (massEfficiency <= upgradeSpec.MassHighTrigger and energyEfficiency <= upgradeSpec.EnergyHighTrigger) then
+                    --LOG('* AI-Swarm: hi_trigger_good = true')
+                else
+                    --LOG(aiBrain.Nickname.. " " ..repr(unit:GetBlueprint().Description.. " " ..unit.Sync.id.. " High Trigger FAILS "))
+                    continue
                 end
-                if not (energyTrend >= energyMaintenance) then
-                    --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS Maintenance trigger "..energyTrend.." "..energyMaintenance)  
-                end
-                if not ( massStorage >= (massNeeded * .8)) then
-                    --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS MASS storage trigger "..massStorage.." needed "..(massNeeded*.8) )
-                end
-                if not (energyStorage > (energyNeeded * .4)) then
-                    --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS ENER storage trigger "..energyStorage.." needed "..(energyNeeded*.4) )
+
+                if ( massTrend >= massTrendNeeded and energyTrend >= energyTrendNeeded and energyTrend >= energyMaintenance )
+                    or ( massStorage >= (massNeeded * .7) and energyStorage > (energyNeeded * .7) ) or bypasseco then
+                    -- we need to have 15% of the resources stored -- some things like MEX can bypass this last check
+                    if (massStorage > ( massNeeded * .15 * upgradeSpec.MassLowTrigger) and energyStorage > ( energyNeeded * .15 * upgradeSpec.EnergyLowTrigger)) or bypasseco then
+
+                        if aiBrain.UpgradeIssued < aiBrain.UpgradeIssuedLimit then
+
+                            if not unit.Dead then
+
+                                upgradeIssued = true
+                                --LOG(aiBrain.Nickname.. " " ..repr(unit:GetBlueprint().Description.. " " ..unit.Sync.id.. " Upgrading to " ..repr(upgradebp.Description)))
+                                IssueUpgrade({unit}, upgradeID)
+
+                                -- if upgrade issued and not completely full --
+                                if massStorageRatio < 1 or energyStorageRatio < 1 then
+                                    ForkThread(StructureUpgradeDelaySwarm, aiBrain, aiBrain.UpgradeIssuedPeriod)  -- delay the next upgrade by the full amount
+                                else
+                                    ForkThread(StructureUpgradeDelaySwarm, aiBrain, aiBrain.UpgradeIssuedPeriod * .5)     -- otherwise halve the delay period
+                                end
+
+                                while (not unit.Dead) and (not unit.UnitBeingBuilt.Blueprint.BlueprintId == upgradeID) do
+                                    SWARMWAIT(50)
+                                end
+                            end
+
+                            if unit.Dead then
+                                --LOG("*AI DEBUG "..aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." to "..upgradeID.." failed.  Dead is "..repr(unit.Dead))
+                                upgradeIssued = false
+                            end
+
+                            if upgradeIssued then
+                                SWARMWAIT(10)
+                                continue
+                            end
+                        else
+                            LOG(aiBrain.Nickname.. " Could not do an upgrade because the UpgradeIssuedLimit was exceeded " .. repr(aiBrain.UpgradeIssued) .. " and UpgradedIsssuedLimit was actually " .. repr(aiBrain.UpgradeIssuedLimit))
+                        end
+                    end
+                else
+                    if not ( massTrend >= massTrendNeeded ) then
+                        --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS MASS Trend trigger "..massTrend.." needed "..massTrendNeeded)
+                    end
+                    if not ( energyTrend >= energyTrendNeeded ) then
+                        --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS ENER Trend trigger "..energyTrend.." needed "..energyTrendNeeded)
+                    end
+                    if not (energyTrend >= energyMaintenance) then
+                        --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS Maintenance trigger "..energyTrend.." "..energyMaintenance)  
+                    end
+                    if not ( massStorage >= (massNeeded * .8)) then
+                        --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS MASS storage trigger "..massStorage.." needed "..(massNeeded*.8) )
+                    end
+                    if not (energyStorage > (energyNeeded * .4)) then
+                        --LOG(aiBrain.Nickname.." STRUCTUREUpgrade "..unit.Sync.id.." "..unit:GetBlueprint().Description.." FAILS ENER storage trigger "..energyStorage.." needed "..(energyNeeded*.4) )
+                    end
                 end
             end
         end
@@ -572,6 +583,7 @@ function ExtractorClosestSwarm(aiBrain, unit, unitBp)
     local BasePosition = aiBrain.BuilderManagers['MAIN'].Position
     local DistanceToBase = nil
     local LowestDistanceToBase = nil
+    local lowestUnitPos
     local UnitPos
 
     if unitType == 'MASSEXTRACTION' and unitTech == 'TECH1' then

--- a/hook/lua/platoon.lua
+++ b/hook/lua/platoon.lua
@@ -6470,6 +6470,9 @@ Platoon = Class(SwarmPlatoonClass) {
     end,
 
     ExtractorCallForHelpAISwarm = function(self, aiBrain)
+        if not aiBrain.InterestList then
+            aiBrain:BuildScoutLocationsSwarm()
+        end
         local checkTime = self.PlatoonData.DistressCheckTime or 4
         local pos = GetPlatoonPosition(self)
         while PlatoonExists(aiBrain, self) and pos do

--- a/hook/lua/sim/EngineerManager.lua
+++ b/hook/lua/sim/EngineerManager.lua
@@ -1,4 +1,5 @@
 local SwarmUtils = import('/mods/AI-Swarm/lua/AI/Swarmutilities.lua')
+local ALLBPS = __blueprints
 
 SwarmEngineerManager = EngineerManager
 EngineerManager = Class(SwarmEngineerManager) {
@@ -9,17 +10,15 @@ EngineerManager = Class(SwarmEngineerManager) {
         end
         if EntityCategoryContains(categories.FACTORY * categories.STRUCTURE, finishedUnit) and finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
             self.Brain.BuilderManagers[self.LocationType].FactoryManager:AddFactory(finishedUnit)
-            local unitBp = finishedUnit:GetBlueprint()
-			local upgradeID = unitBp.General.UpgradesTo or false
-			if upgradeID and unitBp then
+			local upgradeID = finishedUnit.Blueprint.General.UpgradesTo or false
+			if upgradeID then
 				-- if upgradeID available then launch upgrade thread
 				SwarmUtils.StructureUpgradeInitializeSwarm(finishedUnit, self.Brain)
 			end
         end
         if EntityCategoryContains(categories.MASSEXTRACTION * categories.STRUCTURE, finishedUnit) and finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
-            local unitBp = finishedUnit:GetBlueprint()
-            local upgradeID = unitBp.General.UpgradesTo or false
-			if upgradeID and unitBp then
+            local upgradeID = finishedUnit.Blueprint.General.UpgradesTo or false
+			if upgradeID then
 				--LOG('* AI-Swarm: UpgradeID')
 				SwarmUtils.StructureUpgradeInitializeSwarm(finishedUnit, self.Brain)
             end

--- a/lua/AI/AIBuilders/Land units Build.lua
+++ b/lua/AI/AIBuilders/Land units Build.lua
@@ -525,7 +525,7 @@ BuilderGroup { BuilderGroupName = 'Swarm Land Scout Formers',
     BuildersType = 'PlatoonFormBuilder',
     
     Builder { BuilderName = 'Swarm Land Scout',
-        PlatoonTemplate = 'T1LandScoutForm',
+        PlatoonTemplate = 'T1LandScoutFormSwarm',
         Priority = 10000,
         InstanceCount = 10,
         BuilderConditions = {

--- a/lua/AI/PlatoonTemplates/PlatoonTemplates Land.lua
+++ b/lua/AI/PlatoonTemplates/PlatoonTemplates Land.lua
@@ -9,6 +9,14 @@ PlatoonTemplate {
 }
 
 PlatoonTemplate {
+    Name = 'T1LandScoutFormSwarm',
+    Plan = 'ScoutingAISwarm',
+    GlobalSquads = {
+        { categories.MOBILE * categories.SCOUT * categories.TECH1, 1, 1, 'scout', 'none' }
+    }
+}
+
+PlatoonTemplate {
     Name = 'AISwarm LandAttack Micro - Basic',
     Plan = 'HuntAISwarm',
     GlobalSquads = {


### PR DESCRIPTION
This PR does the following.
Add HQ checks to the upgrade thread so that support factories wont try to upgrade when an HQ isn't available. This would cause issues where the T2 supports would upgrade but be unable to produce t3 units and then bring the economy down so that the HQ would never upgrade.
Fix land scout builder. The default uses the navmesh so would cause problems with swarm.
Fix BuildScoutLocations function. This was a little broken.
Fix parseintelthread. This was not looking at the threat table positions correctly.

This should improve swarms functionality a little more. 
